### PR TITLE
Add test for custom unmapping via ko.viewmodel.toModel

### DIFF
--- a/Tests/nestedObject-qunit-tests.js
+++ b/Tests/nestedObject-qunit-tests.js
@@ -219,6 +219,25 @@ test("Custom map and unmap", function () {
     deepEqual(modelResult.data.date, updatedModel.data.date, "To Model Date Test");
 });
 
+test("Custom map and unmap using ko.viewmodel", function () {
+    var viewmodel = ko.viewmodel.fromModel(model, {
+        custom: {
+            "{root}.data": {
+                map: function (data) {
+                    return ko.viewmodel.fromModel(data);
+                },
+                unmap: function(data) {
+                    return ko.viewmodel.toModel(data);
+                }
+            }
+        }
+    }),
+    gotModel;
+
+    gotModel = ko.viewmodel.toModel(viewmodel);
+    deepEqual(gotModel, model);
+});
+
 test("Exclude", function () {
 
     var viewmodel = ko.viewmodel.fromModel(model, {


### PR DESCRIPTION
I've added a test for the scenario where you piggyback on ko.viewmodel.fromModel in a custom mapping function and ko.viewmodel.toModel in a custom unmapping function. This scenario currently leads to infinite recursion in the unmapping function. See the [issue](https://github.com/coderenaissance/knockout.viewmodel/issues/40) I opened previously regarding this problem.
