### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@ options:{
         There is also this alternate syntax if you need to do unmapping:
         <pre><code>
 options:{ 
-    custom:{
+    extend:{
         "{root}.users[i]": {
             map:function(mapped){
                 mapped.isDeleted= ko.observable(false);


### PR DESCRIPTION
The example for options->extend in map/unmap notation falsely uses option->custom even though it is in the extend chapter
